### PR TITLE
Use active model serializer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :test do
   gem "faker", "~> 3.5", ">= 3.5.1"
   gem "database_cleaner", "~> 2.1"
 end
+
+gem "active_model_serializers", "~> 0.10.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,11 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (8.0.2)
       activesupport (= 8.0.2)
       globalid (>= 0.3.6)
@@ -82,6 +87,8 @@ GEM
     brakeman (7.0.2)
       racc
     builder (3.3.0)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -122,6 +129,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.10.2)
+    jsonapi-renderer (0.2.2)
     kamal (2.5.3)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -338,6 +346,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.2)
   bootsnap
   brakeman (~> 7.0.2)
   database_cleaner (~> 2.1)

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,0 +1,3 @@
+class PostSerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -1,3 +1,12 @@
 class PostSerializer < ActiveModel::Serializer
-  attributes :id
+  attributes :id, :title, :content, :published, :author
+
+  def author
+    user = self.object.user
+    {
+      name: user.name,
+      email: user.email,
+      id: user.id
+    }
+  end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe "Posts endpoints", type: :request do
       payload = JSON.parse(response.body)
       expect(payload).to_not be_empty
       expect(payload["id"]).to eq(post.id)
+      expect(payload["title"]).to eq(post.title)
+      expect(payload["content"]).to eq(post.content)
+      expect(payload["published"]).to eq(post.published)
+      expect(payload["author"]["name"]).to eq(post.user.name)
+      expect(payload["author"]["email"]).to eq(post.user.email)
+      expect(payload["author"]["id"]).to eq(post.user.id)
       expect(response).to have_http_status(200)
     end
   end


### PR DESCRIPTION
This pull request introduces a new serializer for the `Post` model and updates the tests accordingly. The key changes include adding the `active_model_serializers` gem, creating the `PostSerializer` class, and updating the request specs to test the new serializer.

### Serializer and Gem Addition:

* Added `active_model_serializers` gem to the `Gemfile` to enable serialization of models.
* Created `PostSerializer` class to define the attributes and custom `author` method for the `Post` model.

### Test Updates:

* Updated `spec/requests/posts_spec.rb` to include new expectations for the serialized `Post` attributes, including `title`, `content`, `published`, and `author` details.User ActiveModelSerializer for post model.