### PR TITLE
Refactor the posts search service in order to use cache

### DIFF
--- a/app/services/posts_search_service.rb
+++ b/app/services/posts_search_service.rb
@@ -1,5 +1,9 @@
 class PostsSearchService
   def self.search(curr_posts, query)
-    curr_posts.where("title LIKE ?", "%#{query}%")
+    posts_ids = Rails.cache.fetch("posts_search/#{query}", expires_in: 1.hours) do
+      curr_posts.where("title LIKE ?", "%#{query}%").map(&:id)
+    end
+
+    curr_posts.where(id: posts_ids)
   end
 end


### PR DESCRIPTION
This pull request introduces a performance improvement to the `PostsSearchService` by leveraging caching to optimize repeated search queries.

Performance optimization:

* [`app/services/posts_search_service.rb`](diffhunk://#diff-ec4d89752eaea9003f0352759f1d3be7f24998dd4b606156e70fab98edca1f68L3-R7): Added caching for search queries using `Rails.cache.fetch`, storing the IDs of matching posts for one hour to reduce database query load on repeated searches.