### PR TITLE
Generate basic structure of post_report job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem "rspec-rails", "~> 7.1", ">= 7.1.1"
   gem "factory_bot_rails", "~> 6.4", ">= 6.4.4"
   gem "faker", "~> 3.5", ">= 3.5.1"
+  gem "letter_opener", "~> 1.4", ">= 1.4.1"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -89,6 +91,8 @@ GEM
     builder (3.3.0)
     case_transform (0.2)
       activesupport
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -142,6 +146,12 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.4)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.0)
@@ -196,6 +206,7 @@ GEM
     psych (5.2.3)
       date
       stringio
+    public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -354,6 +365,7 @@ DEPENDENCIES
   factory_bot_rails (~> 6.4, >= 6.4.4)
   faker (~> 3.5, >= 3.5.1)
   kamal
+  letter_opener (~> 1.4, >= 1.4.1)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 8.0.1)

--- a/app/jobs/post_report_job.rb
+++ b/app/jobs/post_report_job.rb
@@ -5,5 +5,7 @@ class PostReportJob < ApplicationJob
     user = User.find(user_id)
     post = Post.find(post_id)
     report = PostReport.generate(post)
+
+    PostReportMailer.post_report(user, post, report).deliver_now
   end
 end

--- a/app/jobs/post_report_job.rb
+++ b/app/jobs/post_report_job.rb
@@ -1,0 +1,9 @@
+class PostReportJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id, post_id)
+    user = User.find(user_id)
+    post = Post.find(post_id)
+    report = PostReport.generate(post)
+  end
+end

--- a/app/mailers/post_report_mailer.rb
+++ b/app/mailers/post_report_mailer.rb
@@ -1,0 +1,6 @@
+class PostReportMailer < ApplicationMailer
+  def post_report(user, post, post_report)
+    @post = post
+    mail to: user.email, subject: "Post #{post.id} report"
+  end
+end

--- a/app/models/post_report.rb
+++ b/app/models/post_report.rb
@@ -1,0 +1,20 @@
+class PostReport < Struct.new(:word_count, :word_histogram)
+  def self.generate(post)
+    PostReport.new(
+      post.content.split.map { |word| word.gsub(/\w/, "") }.count,
+      calc_histogram(post)
+    )
+  end
+
+  private
+
+  def sef.calc_histogram(post)
+    (post
+      .content
+      .split
+      .map { |word| word.gsub(/\w/, "") }
+      .map(&:downcase)
+      .group_by { |word| word })
+      .transform_values(&:size)
+  end
+end

--- a/app/models/post_report.rb
+++ b/app/models/post_report.rb
@@ -8,13 +8,13 @@ class PostReport < Struct.new(:word_count, :word_histogram)
 
   private
 
-  def sef.calc_histogram(post)
+  def self.calc_histogram(post)
     (post
       .content
       .split
       .map { |word| word.gsub(/\w/, "") }
       .map(&:downcase)
-      .group_by { |word| word })
-      .transform_values(&:size)
+      .group_by { |word| word }
+      .transform_values(&:size))
   end
 end

--- a/app/views/post_report_mailer/post_report.text.erb
+++ b/app/views/post_report_mailer/post_report.text.erb
@@ -1,0 +1,2 @@
+Post id: <%= @post.id %>
+Post title: <%= @post.title   %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
 
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/spec/jobs/post_report_job_spec.rb
+++ b/spec/jobs/post_report_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PostReportJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/post_report_mailer_spec.rb
+++ b/spec/mailers/post_report_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe PostReportMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/post_report_mailer_preview.rb
+++ b/spec/mailers/previews/post_report_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/post_report_mailer
+class PostReportMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/previews/post_report_mailer_preview.rb
+++ b/spec/mailers/previews/post_report_mailer_preview.rb
@@ -1,4 +1,3 @@
 # Preview all emails at http://localhost:3000/rails/mailers/post_report_mailer
 class PostReportMailerPreview < ActionMailer::Preview
-
 end


### PR DESCRIPTION
This pull request introduces functionality to generate and email post reports, along with necessary configurations and placeholders for testing. The most important changes include the addition of a job for generating and sending post reports, a mailer for email delivery, a model to handle report generation, and updates to the development environment for email previews.

### New functionality for post reports:
* [`app/jobs/post_report_job.rb`](diffhunk://#diff-160932f1b8ba06ecbd4e6d19554afacc9adef8bb76e9d0c935ada88984869ef8R1-R11): Added `PostReportJob`, which fetches a user and post, generates a report, and sends it via email using the `PostReportMailer`.
* [`app/mailers/post_report_mailer.rb`](diffhunk://#diff-49faadfde1ad41d98c44a9bcadada0a0c23544d673bb0b70b22413dbfdcaf88cR1-R6): Added `PostReportMailer` to handle the email delivery of post reports with a subject line including the post ID.
* [`app/models/post_report.rb`](diffhunk://#diff-7119098ee55d3a175094fddea7044e24fc8cd196e9f451f707661a0632465f8cR1-R20): Added `PostReport` model to generate a word count and word histogram from post content.

### Email configuration and templates:
* [`config/environments/development.rb`](diffhunk://#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47R40): Configured `letter_opener` as the delivery method for emails in the development environment.
* [`app/views/post_report_mailer/post_report.text.erb`](diffhunk://#diff-400e095eab6c7f99b84d86688edd3b0cdeeb10ee650804dfaa43469d14c814b0R1-R2): Added a basic email template displaying the post ID and title.

### Testing placeholders:
* [`spec/jobs/post_report_job_spec.rb`](diffhunk://#diff-8e1db222318f999ff161a9d534dce86dcc64145431a414a22dbc5b5c8337c43fR1-R5): Added a placeholder spec for `PostReportJob`.
* [`spec/mailers/post_report_mailer_spec.rb`](diffhunk://#diff-a557e916215a6807ca1e606abfe569dede78ad6d8afc235c1615ca8a47fbad4cR1-R5): Added a placeholder spec for `PostReportMailer`.
* [`spec/mailers/previews/post_report_mailer_preview.rb`](diffhunk://#diff-0a018a3aaebdaa3b0699548bd9d36f4fceec520e9f9b86d0c495dfd498b26b74R1-R3): Added a preview class for `PostReportMailer` to enable email previews in development.

### Dependency update:
* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR50): Added the `letter_opener` gem to the `:development, :test` group for easier email debugging during development.This pull request introduces functionality for generating reports on posts, including a new job class, a supporting model, and a placeholder test file. The most important changes involve the creation of the `PostReportJob` for report generation and the `PostReport` model for encapsulating report data and logic.

### New functionality for post report generation:

* [`app/jobs/post_report_job.rb`](diffhunk://#diff-160932f1b8ba06ecbd4e6d19554afacc9adef8bb76e9d0c935ada88984869ef8R1-R9): Added the `PostReportJob` class, which queues a background job to generate a report for a specific post by a user.
* [`app/models/post_report.rb`](diffhunk://#diff-7119098ee55d3a175094fddea7044e24fc8cd196e9f451f707661a0632465f8cR1-R20): Added the `PostReport` model, which includes methods to calculate the word count and a word frequency histogram for a post's content.

### Testing:

* [`spec/jobs/post_report_job_spec.rb`](diffhunk://#diff-8e1db222318f999ff161a9d534dce86dcc64145431a414a22dbc5b5c8337c43fR1-R5): Added a placeholder RSpec test file for `PostReportJob` with a pending test.…or post_report and it methods